### PR TITLE
Replaced console.log() with yeoman's context log

### DIFF
--- a/generators/vagrant/index.js
+++ b/generators/vagrant/index.js
@@ -141,7 +141,7 @@ module.exports = baseGenerator.extend(
 
 				_.each( staticFilenames, function( fn ) {
 
-					console.log("\n\n--> " + fn);
+					me.log("\n\n--> " + fn);
 					me.fs.copy(
 						me.templatePath( "core/env/vagrant/_" + fn ), me.destinationPath( "env/vagrant/" + fn )
 					);


### PR DESCRIPTION
http://yeoman.io/authoring/user-interactions.html

> ... it is important to never use console.log() or process.stdout.write() to output content. Using them would hide the output from users not using a terminal. Instead, always rely on the UI generic this.log() method, where this is the context of your current generator.